### PR TITLE
Method/plot odf section

### DIFF
--- a/matflow_mtex/main.py
+++ b/matflow_mtex/main.py
@@ -710,6 +710,8 @@ def multiple_miller_indices_formatter(miller_directions):
 
 @cli_format_mapper(input_name='use_contours', task='visualise_orientations', method='pole_figure')
 @cli_format_mapper(input_name='use_contours', task='visualise_volume_element_response', method='texture_pole_figure')
+@cli_format_mapper(input_name='use_contours', task='visualise_orientations', method='odf_section')
+@cli_format_mapper(input_name='use_contours', task='visualise_volume_element_response', method='texture_odf_section')
 def bool_cli_formatter(arg):
     # Note we should use the `ensure_double` snippet in the matlab script as well.
     return f'{1 if arg else 0}'

--- a/matflow_mtex/main.py
+++ b/matflow_mtex/main.py
@@ -696,6 +696,8 @@ def reference_frame_formatter(ref_frame):
 
 @cli_format_mapper(input_name='pole_figure_directions', task='visualise_orientations', method='pole_figure')
 @cli_format_mapper(input_name='pole_figure_directions', task='visualise_volume_element_response', method='texture_pole_figure')
+@cli_format_mapper(input_name='pole_figure_directions', task='visualise_orientations', method='odf_section')
+@cli_format_mapper(input_name='pole_figure_directions', task='visualise_volume_element_response', method='texture_odf_section')
 def multiple_miller_indices_formatter(miller_directions):
 
     out = (

--- a/matflow_mtex/main.py
+++ b/matflow_mtex/main.py
@@ -402,6 +402,11 @@ def write_ori_coord_sys_from_ODF(path, ODF):
     task='visualise_orientations',
     method='pole_figure',
 )
+@input_mapper(
+    input_file='orientations.json',
+    task='visualise_orientations',
+    method='odf_section',
+)
 def write_orientations(path, orientations, crystal_symmetry):
 
     orientations = validate_orientations(orientations)
@@ -423,8 +428,18 @@ def write_orientations(path, orientations, crystal_symmetry):
 )
 @input_mapper(
     input_file='options.json',
+    task='visualise_volume_element_response',
+    method='texture_odf_section',
+)
+@input_mapper(
+    input_file='options.json',
     task='visualise_orientations',
     method='pole_figure',
+)
+@input_mapper(
+    input_file='options.json',
+    task='visualise_orientations',
+    method='odf_section',
 )
 def write_PF_options_json(path, colourbar_limits, use_one_colourbar):
     
@@ -441,6 +456,11 @@ def write_PF_options_json(path, colourbar_limits, use_one_colourbar):
     input_file='orientations.json',
     task='visualise_volume_element_response',
     method='texture_pole_figure',
+)
+@input_mapper(
+    input_file='orientations.json',
+    task='visualise_volume_element_response',
+    method='texture_odf_section',
 )
 def write_orientations_from_VE_response(path, volume_element_response, increments,
                                         crystal_symmetries, phases,

--- a/matflow_mtex/main.py
+++ b/matflow_mtex/main.py
@@ -344,6 +344,32 @@ def plot_pole_figure():
     return out
 
 
+@sources_mapper(task='visualise_orientations', method='odf_section', script='visualise_orientations')
+@sources_mapper(task='visualise_volume_element_response', method='texture_odf_section', script='visualise_orientations')
+def plot_odf_section():
+
+    script_name = 'visualise_orientations.m'
+    snippets = [
+        {
+            'name': 'plot_odf_section.m',
+            'req_args': [
+                'orientationsPath',
+                'poleFigureDirections',
+                'use_contours',  # todo change to camel case?
+                'IPF_reference_direction', # todo change to camel case?
+                "optionsPath",
+            ],
+        },
+    ]
+    out = {
+        'script': {
+            'content': get_wrapper_script(script_name, snippets),
+            'filename': script_name,
+        }
+    }
+    return out
+
+
 @input_mapper(input_file='ODF.txt', task='sample_texture', method='from_ODF')
 def write_ODF_file(path, ODF):
     'Write out ODF into an "MTEX" text file'

--- a/matflow_mtex/scripting.py
+++ b/matflow_mtex/scripting.py
@@ -33,6 +33,12 @@ SNIPPETS_ARG_TYPES = {
             'use_contours': 'double',
         }
     },
+    'plot_odf_section.m': {
+        'ensure_types': {
+            'poleFigureDirections': '2D_cell_array',
+            'use_contours': 'double',
+        }
+    },
 }
 
 

--- a/matflow_mtex/snippets/plot_odf_section.m
+++ b/matflow_mtex/snippets/plot_odf_section.m
@@ -68,18 +68,9 @@ function exitcode = plot_odf_section(orientationsPath, poleFigureDirections, use
 
         newMtexFigure('layout', [1, 1], 'visible', 'off');
         plotx2east;
-
-        if use_contours
-            plot(odf, 'PHI2', 45*degree);
-            mtexColorbar;
-        else
-            ipfKey = ipfColorKey(crystalSym);
-            ipfKey.inversePoleFigureDirection = vector3d.(upper(IPF_reference_direction));
-            oriColors = ipfKey.orientation2color(orientations);
-            plot(odf, 'PHI2', 45*degree);
-
-
-        end
+        odf = calcDensity(orientations, 'kernel', deLaValleePoussinKernel, 'halfwidth', 5*degree);
+        plotSection(odf, 'contourf', 'phi2', slice*degree, 'minmax');
+        mtexColorbar ('location', 'southoutside', 'title', 'mrd', 'FontSize', 24);
 
         if isfield(allOpts, "colourbar_limits");
             CLim(gcm, allOpts.colourbar_limits);

--- a/matflow_mtex/snippets/plot_odf_section.m
+++ b/matflow_mtex/snippets/plot_odf_section.m
@@ -177,9 +177,9 @@ function exitcode = plot_odf_section(orientationsPath, poleFigureDirections, use
         end
 
         if isfield(ori_data, 'increment')
-            fileName = sprintf('pole_figure_inc_%d.png', ori_data.increment);
+            fileName = sprintf('odf_section_inc_%d.png', ori_data.increment);
         else
-            fileName = 'pole_figure.png';
+            fileName = 'odf_section.png';
         end
 
         saveFigure(fileName);

--- a/matflow_mtex/snippets/plot_odf_section.m
+++ b/matflow_mtex/snippets/plot_odf_section.m
@@ -69,7 +69,7 @@ function exitcode = plot_odf_section(orientationsPath, poleFigureDirections, use
         newMtexFigure('layout', [1, 1], 'visible', 'off');
         plotx2east;
         odf = calcDensity(orientations, 'kernel', deLaValleePoussinKernel, 'halfwidth', 5*degree);
-        plotSection(odf, 'contourf', 'phi2', slice*degree, 'minmax');
+        plotSection(odf, 'contourf', 'phi2', 45*degree, 'minmax');
         mtexColorbar ('location', 'southoutside', 'title', 'mrd', 'FontSize', 24);
 
         if isfield(allOpts, "colourbar_limits");

--- a/matflow_mtex/snippets/plot_odf_section.m
+++ b/matflow_mtex/snippets/plot_odf_section.m
@@ -1,4 +1,4 @@
-function exitcode = plot_pole_figure(orientationsPath, poleFigureDirections, use_contours, IPF_reference_direction, optionsPath)
+function exitcode = plot_odf_section(orientationsPath, poleFigureDirections, use_contours, IPF_reference_direction, optionsPath)
 
     allOriData = jsondecode(fileread(orientationsPath));
     allOpts = jsondecode(fileread(optionsPath));

--- a/matflow_mtex/snippets/plot_odf_section.m
+++ b/matflow_mtex/snippets/plot_odf_section.m
@@ -1,0 +1,198 @@
+function exitcode = plot_pole_figure(orientationsPath, poleFigureDirections, use_contours, IPF_reference_direction, optionsPath)
+
+    allOriData = jsondecode(fileread(orientationsPath));
+    allOpts = jsondecode(fileread(optionsPath));
+
+    for PFIdx = 1:length(allOriData)
+
+        ori_data = allOriData(PFIdx);
+        crystalSym = ori_data.crystal_symmetry
+
+        alignment = {};
+
+        if isfield(ori_data.unit_cell_alignment, 'x');
+            alignment{end + 1} = sprintf('X||%s', ori_data.unit_cell_alignment.x);
+        end
+
+        if isfield(ori_data.unit_cell_alignment, 'y');
+            alignment{end + 1} = sprintf('Y||%s', ori_data.unit_cell_alignment.y);
+        end
+
+        if isfield(ori_data.unit_cell_alignment, 'z');
+            alignment{end + 1} = sprintf('Z||%s', ori_data.unit_cell_alignment.z);
+        end
+
+        crystalSym = crystalSymmetry(crystalSym, alignment{:});
+        millerDirs = Miller(poleFigureDirections{1}, crystalSym);
+
+        for i = 2:length(poleFigureDirections)
+            newMillerDir = Miller(poleFigureDirections{i}, crystalSym);
+            millerDirs = [millerDirs, newMillerDir];
+        end
+
+        if strcmp(ori_data.type, 'quat')
+
+            quat_data = ori_data.quaternions;
+
+            if ori_data.P == 1
+                % Scale vector part by -1:
+                % This works "accidentally" - the requirement for inverting is due to
+                % MTEX adopting a crystal->specimen convention rather than specimen->crystal
+                % needs fixing!
+                quat_data(:, 2:end) = quat_data(:, 2:end) * -1;
+            end
+
+            if strcmp(ori_data.quat_component_ordering, 'vector-scalar')
+                % Swap to scalar-vector order:
+                quat_data = circshift(quat_data, 1, 2);
+            end
+
+            quats = quaternion(quat_data.');
+            orientations = orientation(quats, crystalSym);
+
+        elseif strcmp(ori_data.type, 'euler')
+
+            if ori_data.euler_degrees
+                orientations = orientation.byEuler( ...
+                    ori_data.euler_angles * degree, ...
+                    crystalSym ...
+                );
+            else
+                orientations = orientation.byEuler( ...
+                    ori_data.euler_angles, ...
+                    crystalSym ...
+                );
+            end
+
+        end
+
+        newMtexFigure('layout', [1, 1], 'visible', 'off');
+        plotx2east;
+
+        if use_contours
+            plot(odf, 'PHI2', 45*degree);
+            mtexColorbar;
+        else
+            ipfKey = ipfColorKey(crystalSym);
+            ipfKey.inversePoleFigureDirection = vector3d.(upper(IPF_reference_direction));
+            oriColors = ipfKey.orientation2color(orientations);
+            plot(odf, 'PHI2', 45*degree);
+
+
+        end
+
+        if isfield(allOpts, "colourbar_limits");
+            CLim(gcm, allOpts.colourbar_limits);
+        end
+
+        if isfield(allOpts, "use_one_colourbar");
+            mtexColorbar % remove colorbars
+            CLim(gcm, 'equal');
+            mtexColorbar % add a single colorbar
+        end
+
+        aAxis = Miller(crystalSym.aAxis, 'xyz');
+        bAxis = Miller(crystalSym.bAxis, 'xyz');
+        cAxis = Miller(crystalSym.cAxis, 'xyz');
+
+        xyzVecs = eye(3);
+        xyzLabels = {'x', 'y', 'z'};
+        aLabelAdded = 0;
+        bLabelAdded = 0;
+        cLabelAdded = 0;
+
+        for i = 1:3
+
+            if round(aAxis.xyz, 10) == xyzVecs(i, :)
+                aLabelAdded = 1;
+                xyzLabels(i) = append(xyzLabels(i), '/a');
+            end
+
+            if round(bAxis.xyz, 10) == xyzVecs(i, :)
+                bLabelAdded = 1;
+                xyzLabels(i) = append(xyzLabels(i), '/b');
+            end
+
+            if round(cAxis.xyz, 10) == xyzVecs(i, :)
+                cLabelAdded = 1;
+                xyzLabels(i) = append(xyzLabels(i), '/c');
+            end
+
+        end
+
+        if isfield(ori_data, 'orientation_coordinate_system')
+
+            if isstruct(ori_data.orientation_coordinate_system)
+
+                if isfield(ori_data.orientation_coordinate_system, 'x')
+                    xyzLabels(1) = append( ...
+                        xyzLabels(1), ...
+                        sprintf('/%s', ori_data.orientation_coordinate_system.x) ...
+                    );
+                end
+
+                if isfield(ori_data.orientation_coordinate_system, 'y')
+                    xyzLabels(2) = append( ...
+                        xyzLabels(2), ...
+                        sprintf('/%s', ori_data.orientation_coordinate_system.y) ...
+                    );
+                end
+
+                if isfield(ori_data.orientation_coordinate_system, 'z')
+                    xyzLabels(3) = append( ...
+                        xyzLabels(3), ...
+                        sprintf('/%s', ori_data.orientation_coordinate_system.z) ...
+                    );
+                end
+
+                annotate( ...
+                    [xvector, yvector, zvector], ...
+                    'label', { ...
+                        ori_data.orientation_coordinate_system.x, ...
+                        ori_data.orientation_coordinate_system.y, ...
+                        ori_data.orientation_coordinate_system.z ...
+                    }, ...
+                    'backgroundcolor', 'w' ...
+                )
+            end
+
+        end
+
+        annotate( ...
+            [xvector, yvector, zvector], ...
+            'label', {xyzLabels{1}, xyzLabels{2}, xyzLabels{3}}, ...
+            'backgroundcolor', 'w' ...
+        )
+
+        if ~aLabelAdded
+            annotate([crystalSym.aAxis], 'label', {'a'}, 'backgroundcolor', 'w');
+        end
+
+        if ~bLabelAdded
+            annotate([crystalSym.bAxis], 'label', {'b'}, 'backgroundcolor', 'w');
+        end
+
+        if ~cLabelAdded
+            annotate([crystalSym.cAxis], 'label', {'c'}, 'backgroundcolor', 'w');
+        end
+
+        if isfield(ori_data, 'increment')
+            fileName = sprintf('pole_figure_inc_%d.png', ori_data.increment);
+        else
+            fileName = 'pole_figure.png';
+        end
+
+        saveFigure(fileName);
+
+        if PFIdx == 1 && ~use_contours
+            newMtexFigure('layout', [1, 1], 'visible', 'off');
+            plot(ipfKey);
+            saveFigure('IPF_key.png');
+        end
+
+        close all;
+
+    end
+
+    exitcode = 1;
+end


### PR DESCRIPTION
**This pull request is to allow the user the ability to plot odf sections in place of pole figures with the `visualise_volume_element_response` task using the method `texture_odf_section`.**

For the time being, I just need to ensure this works, so have replicated any code for plotting pole figures and changing `pole_figure` to `odf_section` where applicable.

- [ ] Ideally the user may define the euler angle (phi1, PHI, phi2) and value in degrees for this task, but to start with mtex should plot the phi2 45 degree section by default.
- [ ] Next, the user should also be able to define whether they would like points on the plot for each orientation or contours representing the ODF. Initially, both options have been set to produce the contured ODF section.

Please comment here for any further suggestions on improvements. Thanks, Guy