### PR TITLE
Gbowker/method/from odf mat

### DIFF
--- a/matflow_mtex/main.py
+++ b/matflow_mtex/main.py
@@ -369,6 +369,7 @@ def plot_pole_figure():
 
 
 @input_mapper(input_file='ODF.txt', task='sample_texture', method='from_ODF')
+@input_mapper(input_file='ODF.mat', task='sample_texture', method='from_ODF_mat')
 def write_ODF_file(path, ODF):
     'Write out ODF into an "MTEX" text file'
 
@@ -389,6 +390,11 @@ def write_ODF_file(path, ODF):
     input_file='orientation_coordinate_system.json',
     task='sample_texture',
     method='from_ODF',
+)
+@input_mapper(
+    input_file='orientation_coordinate_system.json',
+    task='sample_texture',
+    method='from_ODF_mat',
 )
 def write_ori_coord_sys_from_ODF(path, ODF):
     with Path(path).open('w') as handle:
@@ -579,6 +585,7 @@ def parse_MTEX_ODF_file(path, orientation_coordinate_system):
 
 
 @output_mapper(output_name='orientations', task='sample_texture', method='from_ODF')
+@output_mapper(output_name='orientations', task='sample_texture', method='from_ODF_mat')
 def parse_orientations(path, ori_coord_sys_path):
 
     with Path(path).open() as handle:

--- a/matflow_mtex/main.py
+++ b/matflow_mtex/main.py
@@ -586,7 +586,7 @@ def parse_MTEX_ODF_file(path, orientation_coordinate_system):
 
 @output_mapper(output_name='orientations', task='sample_texture', method='from_ODF')
 @output_mapper(output_name='orientations', task='sample_texture', method='from_ODF_mat')
-def parse_orientations(path, ori_coord_sys_path):
+def parse_orientations(path, orientation_coordinate_system):
 
     with Path(path).open() as handle:
         ln = handle.readline()
@@ -594,13 +594,10 @@ def parse_orientations(path, ori_coord_sys_path):
 
     euler_angles = np.loadtxt(str(path), skiprows=1, ndmin=2)
 
-    with Path(ori_coord_sys_path).open() as handle:
-        ori_coord_sys = json.load(handle)
-
     orientations = {
         'euler_angle_labels': euler_angle_labels,
         'euler_angles': euler_angles,
-        'orientation_coordinate_system': ori_coord_sys,
+        'orientation_coordinate_system': orientation_coordinate_system,
     }
     return orientations
 

--- a/matflow_mtex/main.py
+++ b/matflow_mtex/main.py
@@ -155,7 +155,7 @@ def sample_texture_from_ODF():
 
 
 @sources_mapper(task='sample_texture', method='from_ODF_mat', script='sample_texture')
-def sample_texture_from_ODF():
+def sample_texture_from_ODF_mat():
 
     script_name = 'sample_texture.m'
     snippets = [
@@ -167,7 +167,9 @@ def sample_texture_from_ODF():
             'name': 'sample_ODF_orientations.m',
             'req_args': ['numOrientations'],
         },
-        {'name': 'export_orientations.m'},
+        {
+            'name': 'export_orientations_JSON.m'
+        },
     ]
     out = {
         'script': {
@@ -369,7 +371,6 @@ def plot_pole_figure():
 
 
 @input_mapper(input_file='ODF.txt', task='sample_texture', method='from_ODF')
-@input_mapper(input_file='ODF.mat', task='sample_texture', method='from_ODF_mat')
 def write_ODF_file(path, ODF):
     'Write out ODF into an "MTEX" text file'
 
@@ -390,11 +391,6 @@ def write_ODF_file(path, ODF):
     input_file='orientation_coordinate_system.json',
     task='sample_texture',
     method='from_ODF',
-)
-@input_mapper(
-    input_file='orientation_coordinate_system.json',
-    task='sample_texture',
-    method='from_ODF_mat',
 )
 def write_ori_coord_sys_from_ODF(path, ODF):
     with Path(path).open('w') as handle:
@@ -585,7 +581,6 @@ def parse_MTEX_ODF_file(path, orientation_coordinate_system):
 
 
 @output_mapper(output_name='orientations', task='sample_texture', method='from_ODF')
-@output_mapper(output_name='orientations', task='sample_texture', method='from_ODF_mat')
 def parse_orientations(path, orientation_coordinate_system):
 
     with Path(path).open() as handle:
@@ -605,6 +600,7 @@ def parse_orientations(path, orientation_coordinate_system):
 @output_mapper(output_name='orientations', task='sample_texture', method='from_model_ODF')
 @output_mapper(output_name='orientations', task='sample_texture', method='from_CTF_file')
 @output_mapper(output_name='orientations', task='sample_texture', method='from_CRC_file')
+@output_mapper(output_name='orientations', task='sample_texture', method='from_ODF_mat')
 @output_mapper(output_name='orientations', task='sample_orientations', method='from_CTF_file')
 @output_mapper(output_name='orientations', task='sample_orientations', method='from_CRC_file')
 def parse_orientations_JSON(path, orientation_coordinate_system):

--- a/matflow_mtex/main.py
+++ b/matflow_mtex/main.py
@@ -154,6 +154,30 @@ def sample_texture_from_ODF():
     return out
 
 
+@sources_mapper(task='sample_texture', method='from_ODF_mat', script='sample_texture')
+def sample_texture_from_ODF():
+
+    script_name = 'sample_texture.m'
+    snippets = [
+        {
+            'name': 'load_ODF_mat.m',
+            'req_args': ['crystalSym', 'specimenSym'],
+        },
+        {
+            'name': 'sample_ODF_orientations.m',
+            'req_args': ['numOrientations'],
+        },
+        {'name': 'export_orientations.m'},
+    ]
+    out = {
+        'script': {
+            'content': get_wrapper_script(script_name, snippets),
+            'filename': script_name,
+        }
+    }
+    return out
+
+
 @sources_mapper(task='sample_texture', method='from_model_ODF', script='sample_texture')
 def sample_texture_from_model_ODF():
 

--- a/matflow_mtex/main.py
+++ b/matflow_mtex/main.py
@@ -161,7 +161,7 @@ def sample_texture_from_ODF():
     snippets = [
         {
             'name': 'load_ODF_mat.m',
-            'req_args': ['crystalSym', 'specimenSym'],
+            'req_args': ['ODF_mat_path', 'crystalSym', 'specimenSym'],
         },
         {
             'name': 'sample_ODF_orientations.m',

--- a/matflow_mtex/scripting.py
+++ b/matflow_mtex/scripting.py
@@ -25,6 +25,7 @@ SNIPPETS_ARG_TYPES = {
     'randomly_sample_EBSD_orientations.m': {'ensure_types': {'numOrientations': 'double'}},
     'sample_ODF_orientations.m': {'ensure_types': {'numOrientations': 'double'}},
     'load_ODF.m': {'defaults': {'ODF_path': 'ODF.txt'}},
+    'load_ODF_mat.m': {},
     'export_orientations.m': {'defaults': {'fileName': 'orientations.txt'}},
     'export_orientations_JSON.m': {'defaults': {'fileName': 'orientations.json'}},
     'plot_pole_figure.m': {

--- a/matflow_mtex/snippets/load_ODF_mat.m
+++ b/matflow_mtex/snippets/load_ODF_mat.m
@@ -1,6 +1,6 @@
 function ODF = load_ODF_mat(ODF_mat_path, crystalSym, specimenSym)
     crystalSym = crystalSymmetry(crystalSym);
-    specimenSym = specimenSymmetry(specimenSym);    
-    ODF = load(ODF_mat_path)
-    );
+    specimenSym = specimenSymmetry(specimenSym);
+    ODF_struct = load(ODF_mat_path);
+    ODF = ODF_struct.odf;
 end

--- a/matflow_mtex/snippets/load_ODF_mat.m
+++ b/matflow_mtex/snippets/load_ODF_mat.m
@@ -1,0 +1,6 @@
+function ODF = load_ODF_mat(ODF_mat_path, crystalSym, specimenSym)
+    crystalSym = crystalSymmetry(crystalSym);
+    specimenSym = specimenSymmetry(specimenSym);    
+    ODF = load(ODF_mat_path)
+    );
+end


### PR DESCRIPTION
I want to add a method `from_ODF_mat` to task `sample texture`. I have already added this into the `dev` branch task schema: [UoM-CSF-matflow/ commit 57e8946](https://github.com/LightForm-group/UoM-CSF-matflow/commit/57e89464cba965da1224eafe66898f9a1aef7d1d)

`ODF.mat` files may be created using MTEX. These contain the ODF as a variable, which can be imported and used in seperate MTEX scripts. Here, the user should be able to define a number of quaternions to sample from this ODF to input into a model. Each phase in a model possesses an individual ODF, which should be distrubuted to its corresponding phase in the model.

![image](https://user-images.githubusercontent.com/61540494/181489303-a5ba0abe-57f1-40f9-99c0-c35d8778ab24.png)